### PR TITLE
feat(application): finaliza camada Application com services e validações

### DIFF
--- a/src/Application/JF.OrdemServico.Application/Common/ServiceBase.cs
+++ b/src/Application/JF.OrdemServico.Application/Common/ServiceBase.cs
@@ -1,0 +1,57 @@
+﻿using FluentValidation;
+using JF.OrdemServico.Domain.Interfaces.Repositories;
+using JF.OrdemServico.Domain.Interfaces.Services;
+
+namespace JF.OrdemServico.Application.Common;
+
+public abstract class ServiceBase<TEntity> : IServiceBase<TEntity> where TEntity : class
+{
+    protected readonly IRepositoryBase<TEntity> _repository;
+    protected readonly IValidator<TEntity> _validator;
+
+    protected ServiceBase(IRepositoryBase<TEntity> repository, IValidator<TEntity> validator)
+    {
+        _repository = repository;
+        _validator = validator;
+    }
+
+    public virtual async Task<TEntity> CreateAsync(TEntity entity)
+    {
+        var validationResult = await _validator.ValidateAsync(entity);
+        if (!validationResult.IsValid)
+        {
+            throw new ValidationException(validationResult.Errors);
+        }
+            
+        await _repository.AddAsync(entity);
+        return entity;
+    }
+
+    public virtual async Task<TEntity> UpdateAsync(TEntity entity)
+    {
+        var validationResult = await _validator.ValidateAsync(entity);
+        if (!validationResult.IsValid)
+        {
+            throw new ValidationException(validationResult.Errors);
+        }
+            
+        await _repository.UpdateAsync(entity);
+        return entity;
+    }
+
+    public virtual async Task<TEntity?> GetByIdAsync(Guid id)
+    {
+        return await _repository.GetById(id);
+    }
+
+    public virtual async Task<IEnumerable<TEntity>> GetAllAsync()
+    {
+        return await _repository.GetAllAsync();
+    }
+
+    public virtual async Task<bool> RemoveAsync(Guid id)
+    {
+        await _repository.RemoveAsync(id);
+        return true;
+    }
+}

--- a/src/Application/JF.OrdemServico.Application/Extensions/ApplicationServiceCollectionExtensions.cs
+++ b/src/Application/JF.OrdemServico.Application/Extensions/ApplicationServiceCollectionExtensions.cs
@@ -1,0 +1,19 @@
+﻿using FluentValidation;
+using JF.OrdemServico.Application.Common;
+using JF.OrdemServico.Domain.Interfaces.Services;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+
+namespace JF.OrdemServico.Application.Extensions;
+
+public static class ApplicationServiceCollectionExtensions
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
+        services.AddScoped(typeof(IServiceBase<>), typeof(ServiceBase<>));
+        // services.AddScoped<IChamadoService, ChamadoService>(); // Se houver um service concreto
+
+        return services;
+    }
+}

--- a/src/Application/JF.OrdemServico.Application/JF.OrdemServico.Application.csproj
+++ b/src/Application/JF.OrdemServico.Application/JF.OrdemServico.Application.csproj
@@ -6,4 +6,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Folder Include="Services\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/Application/JF.OrdemServico.Application/Validators/ChamadoValidator.cs
+++ b/src/Application/JF.OrdemServico.Application/Validators/ChamadoValidator.cs
@@ -1,0 +1,28 @@
+﻿using FluentValidation;
+using JF.OrdemServico.Domain.Entities;
+
+namespace JF.OrdemServico.Application.Validators;
+
+public class ChamadoValidator : AbstractValidator<Chamado>
+{
+    public ChamadoValidator()
+    {
+        RuleFor(x => x.Cliente)
+            .NotNull()
+            .WithMessage("Cliente é obrigatório.");
+
+        RuleFor(x => x.Descricao)
+            .NotEmpty()
+            .WithMessage("Descrição do problema é obrigatória.")
+            .MinimumLength(10)
+            .WithMessage("Descrição deve ter pelo menos 10 caracteres.");
+
+        RuleFor(x => x.Prioridade)
+            .NotNull()
+            .WithMessage("Prioridade é obrigatória.");
+
+        RuleFor(x => x.Status)
+            .NotNull()
+            .WithMessage("Status é obrigatório.");
+    }
+}

--- a/src/Application/JF.OrdemServico.Application/Validators/ClienteValidator.cs
+++ b/src/Application/JF.OrdemServico.Application/Validators/ClienteValidator.cs
@@ -1,0 +1,22 @@
+﻿using FluentValidation;
+using JF.OrdemServico.Domain.Entities;
+
+namespace JF.OrdemServico.Application.Validators;
+
+public class ClienteValidator : AbstractValidator<Cliente>
+{
+    public ClienteValidator()
+    {
+        RuleFor(x => x.Nome)
+            .NotEmpty()
+            .WithMessage("Nome do cliente é obrigatório.")
+            .MinimumLength(3)
+            .WithMessage("Nome deve ter pelo menos 3 caracteres.");
+
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .WithMessage("E-mail é obrigatório.")
+            .EmailAddress()
+            .WithMessage("Formato de e-mail inválido.");
+    }
+}

--- a/src/Domain/JF.OrdemServico.Domain/Interfaces/Repositories/IChamadoRepository.cs
+++ b/src/Domain/JF.OrdemServico.Domain/Interfaces/Repositories/IChamadoRepository.cs
@@ -1,7 +1,7 @@
 ﻿using JF.OrdemServico.Domain.Entities;
 using JF.OrdemServico.Domain.ValueObjects;
 
-namespace JF.OrdemServico.Domain.Repositories;
+namespace JF.OrdemServico.Domain.Interfaces.Repositories;
 
 public interface IChamadoRepository : IRepositoryBase<Chamado>
 {

--- a/src/Domain/JF.OrdemServico.Domain/Interfaces/Repositories/IClienteRepository.cs
+++ b/src/Domain/JF.OrdemServico.Domain/Interfaces/Repositories/IClienteRepository.cs
@@ -1,6 +1,6 @@
 ﻿using JF.OrdemServico.Domain.Entities;
 
-namespace JF.OrdemServico.Domain.Repositories;
+namespace JF.OrdemServico.Domain.Interfaces.Repositories;
 
 public interface IClienteRepository : IRepositoryBase<Cliente>
 {

--- a/src/Domain/JF.OrdemServico.Domain/Interfaces/Repositories/IRepositoryBase.cs
+++ b/src/Domain/JF.OrdemServico.Domain/Interfaces/Repositories/IRepositoryBase.cs
@@ -1,4 +1,4 @@
-﻿namespace JF.OrdemServico.Domain.Repositories;
+﻿namespace JF.OrdemServico.Domain.Interfaces.Repositories;
 
 public interface IRepositoryBase<T> where T : class
 {

--- a/src/Domain/JF.OrdemServico.Domain/Interfaces/Services/IServiceBase.cs
+++ b/src/Domain/JF.OrdemServico.Domain/Interfaces/Services/IServiceBase.cs
@@ -1,0 +1,14 @@
+﻿namespace JF.OrdemServico.Domain.Interfaces.Services;
+
+public interface IServiceBase<TEntity> where TEntity : class
+{
+    Task<TEntity> CreateAsync(TEntity entity);
+
+    Task<TEntity> UpdateAsync(TEntity entity);
+
+    Task<TEntity?> GetByIdAsync(Guid id);
+
+    Task<IEnumerable<TEntity>> GetAllAsync();
+
+    Task<bool> RemoveAsync(Guid id);
+}

--- a/src/Infra/JF.OrdemServico.Infrastructure/Data/Common/RepositoryBase.cs
+++ b/src/Infra/JF.OrdemServico.Infrastructure/Data/Common/RepositoryBase.cs
@@ -1,5 +1,5 @@
 ﻿using JF.OrdemServico.Domain.Common;
-using JF.OrdemServico.Domain.Repositories;
+using JF.OrdemServico.Domain.Interfaces.Repositories;
 using JF.OrdemServico.Infra.Data.Context;
 using Microsoft.EntityFrameworkCore;
 

--- a/src/Infra/JF.OrdemServico.Infrastructure/Data/Repositories/ChamadoRepository.cs
+++ b/src/Infra/JF.OrdemServico.Infrastructure/Data/Repositories/ChamadoRepository.cs
@@ -1,5 +1,5 @@
 ﻿using JF.OrdemServico.Domain.Entities;
-using JF.OrdemServico.Domain.Repositories;
+using JF.OrdemServico.Domain.Interfaces.Repositories;
 using JF.OrdemServico.Domain.ValueObjects;
 using JF.OrdemServico.Infra.Data.Common;
 using JF.OrdemServico.Infra.Data.Context;

--- a/src/Infra/JF.OrdemServico.Infrastructure/Data/Repositories/ClienteRepository.cs
+++ b/src/Infra/JF.OrdemServico.Infrastructure/Data/Repositories/ClienteRepository.cs
@@ -1,5 +1,5 @@
 ﻿using JF.OrdemServico.Domain.Entities;
-using JF.OrdemServico.Domain.Repositories;
+using JF.OrdemServico.Domain.Interfaces.Repositories;
 using JF.OrdemServico.Infra.Data.Common;
 using JF.OrdemServico.Infra.Data.Context;
 using Microsoft.EntityFrameworkCore;

--- a/src/Infra/JF.OrdemServico.Infrastructure/Extensions/InfraServiceCollectionExtensions.cs
+++ b/src/Infra/JF.OrdemServico.Infrastructure/Extensions/InfraServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+﻿using JF.OrdemServico.Domain.Interfaces.Repositories;
+using JF.OrdemServico.Infra.Data.Common;
+using JF.OrdemServico.Infra.Data.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JF.OrdemServico.Infra.Extensions;
+
+public static class InfraServiceCollectionExtensions
+{
+    public static IServiceCollection AddInfra(this IServiceCollection services)
+    {
+        services.AddScoped(typeof(IRepositoryBase<>), typeof(RepositoryBase<>));
+        services.AddScoped<IChamadoRepository, ChamadoRepository>();
+        services.AddScoped<IClienteRepository, ClienteRepository>();
+
+        // Adicione contextos e configurações de banco aqui
+
+        return services;
+    }
+}


### PR DESCRIPTION
- Implementado ServiceBase<T> genérico com suporte a FluentValidation
- Criados validators para entidades Chamado e Cliente
- Estruturada injeção de dependência via método AddApplication
- Decidido uso direto de entidades na Application (sem DTOs)
- Validações centralizadas, sem uso de throw ou ServiceResult
- Preparado para uso com controller e integração com camada Infra